### PR TITLE
Move BIP39 dictionary into flash memory

### DIFF
--- a/src/bip39/bip39.cpp
+++ b/src/bip39/bip39.cpp
@@ -29,7 +29,8 @@ std::string generate_mnemonic(language lang /* = language::en */, uint8_t num_wo
 	std::string passphrase;
 	const auto words = get_string_table(lang);
 	for (auto i = 0; i < num_words; ) {
-		const auto word = words[generate_random_number(0, NUM_BIP39_WORDS - 1, true)];
+		char word[MAX_BIP39_WORD_LENGTH] = {};
+		strcpy_P(word, (char*)pgm_read_ptr_far(&(words[generate_random_number(0, NUM_BIP39_WORDS - 1, true)])));
 		if (passphrase.find(word) == std::string::npos) {
 			passphrase += word;
 			if (i != num_words - 1) {

--- a/src/bip39/en.h
+++ b/src/bip39/en.h
@@ -4,7 +4,7 @@
 #include "bip39/en_str.h"
 #include "utilities/platform.h"
 
-const char* const en_table[] /*PROGMEM*/ = {
+const char* const en_table[] PROGMEM = {
 	STRING_VAR(abandon),
 	STRING_VAR(ability),
 	STRING_VAR(able),

--- a/src/bip39/util.h
+++ b/src/bip39/util.h
@@ -1,7 +1,7 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-#define STRING_VAR_DECL(s) const char s##_str[] /*PROGMEM*/ = #s;
+#define STRING_VAR_DECL(s) const char s##_str[] PROGMEM = #s;
 
 #define STRING_VAR(s) s##_str
 

--- a/src/utilities/platform.h
+++ b/src/utilities/platform.h
@@ -64,6 +64,9 @@ inline uint32_t generate_random_number(uint32_t min, uint32_t max, bool /* stati
 #define PROGMEM
 #define PGM_P const char*
 
+#define pgm_read_ptr_far(p) (*p)
+#define strcpy_P strcpy
+
 #include <string>
 #include <random>
 #include <iostream>


### PR DESCRIPTION
Updated BIP39 dictionary to make use of flash memory instead of RAM.  Added adapter layer for desktop to support single code base.