### PR TITLE
Correct misspelling of includes library.properties field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=A C++/Cpp library with Blockchain/Crypto support for the Ark Ecosystem
 category=Communication
 url=https://github.com/Ark-IoT/Ark-Cpp
 architectures=*
-include=ark.h
+includes=ark.h


### PR DESCRIPTION
The correct spelling of the field name is includes, not include.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format